### PR TITLE
Fix: plugin-better-list be inserted as a plain HTML

### DIFF
--- a/packages/@vpzk/plugin-better-list/src/node/markdownItBetterList.ts
+++ b/packages/@vpzk/plugin-better-list/src/node/markdownItBetterList.ts
@@ -5,9 +5,9 @@ import type * as Renderer from 'markdown-it/lib/renderer'
 const proxy = (tokens: Token[], idx: number, options: Options, _env: any, self: Renderer) => self.renderToken(tokens, idx, options)
 
 export const markdownItBetterList: PluginWithParams = (md): void => {
-  md.renderer.rules.orderder_list_open = () => '<div class="better-list"><div class="better-list-border" /><div>'
+  md.renderer.rules.orderder_list_open = () => '<div class="better-list"><div class="better-list-border"></div><div>'
   md.renderer.rules.orderder_list_close = () => '</div></div>'
-  md.renderer.rules.bullet_list_open = () => '<div class="better-list"><div class="better-list-border" /><div>'
+  md.renderer.rules.bullet_list_open = () => '<div class="better-list"><div class="better-list-border"></div><div>'
   md.renderer.rules.bullet_list_close = () => '</div></div>'
   md.renderer.rules.list_item_open = () => '<div class="better-list-block">'
   md.renderer.rules.list_item_close = () => '</div>'
@@ -21,9 +21,9 @@ export const markdownItBetterList: PluginWithParams = (md): void => {
       if (lastToken.type == 'list_item_open') {
         return `<div class="better-list-title">
           <div class="better-list-bullet">
-            <span class="better-list-bullet-control" />
+            <span class="better-list-bullet-control"></span>
             <span class="better-list-bullet-container">
-              <span class="better-list-bullet-entity" />
+              <span class="better-list-bullet-entity"></span>
             </span>
           </div>
           <div class="better-list-title-content">${defaultParagraphOpen(tokens, idx, options, env, self)}`


### PR DESCRIPTION
When a better-list is inserted as a plain HTML (e.g. with `v-html` or `innerHtml`), the self closed tags (which includes `better-list-border`, `better-list-bullet-control` and `better-list-bullet-entity`) will cause unexpected behavior
as wraps adjacent elements as its child elements.  
![322221660485032_ pic](https://user-images.githubusercontent.com/25029451/184542071-fdbf5ead-1e90-4d46-803b-e6308c81c2ae.jpg)

![322861660486806_ pic](https://user-images.githubusercontent.com/25029451/184542032-cf2ce627-5efe-4e08-9e96-4157341bc204.jpg)
